### PR TITLE
Refer to README.md (not .txt) in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license='BSD',
     description='Python Class for utilizing the Rainforest Automation Eagle ( RFA-Z109 ) socket API.',
     download_url='https://github.com/evilpete/RainEagle/archive/0.1.8.tar.gz',
-    long_description=open('README.txt').read(),
+    long_description=open('README.md').read(),
     cmdclass = { 'install_scripts': install_scripts_and_symlinks }
 )
 


### PR DESCRIPTION
Trying to run 'python2 setup.py' resulted in an error trying to read README.txt
